### PR TITLE
Support Laravel 5.4+

### DIFF
--- a/src/AffiliateNetworkServiceProvider.php
+++ b/src/AffiliateNetworkServiceProvider.php
@@ -34,8 +34,7 @@ class AffiliateNetworkServiceProvider extends ServiceProvider
      */
     public function register()
     {
-
-        $this->app['NetworkManager']=$this->app->share(function ($app) {
+        $this->app->singleton(Connection::class, function ($app) {
             return new NetworkManager();
         });
         $this->app->alias('NetworkManager', NetworkManager::class);


### PR DESCRIPTION
share() is removed in Laravel 5.4.
Here's the fix:

```
php artisan vendor:publish --provider="Padosoft\AffiliateNetwork\AffiliateNetworkServiceProvider"
   Symfony\Component\Debug\Exception\FatalThrowableError  : Call to undefined method Illuminate\Foundation\Application::share()
```